### PR TITLE
Ensure that gl_FragColor.rgb is always properly initialized in final.fsh

### DIFF
--- a/shaders/dimensions/final.fsh
+++ b/shaders/dimensions/final.fsh
@@ -215,9 +215,11 @@ void main() {
     COLOR = imageLoad(cloudDepthTex, ivec2(gl_FragCoord.xy*VL_RENDER_RESOLUTION*RENDER_SCALE)).rgb;
   #endif
 
+  gl_FragColor.rgb = COLOR;
+
   #if DEBUG_VIEW == debug_WATERSIM && WATER_INTERACTION == 2
     if (hideGUI == 1) {
-    gl_FragColor.rgb = vec3(imageLoad(waveSim2, ivec2(gl_FragCoord.xy)*16).x);
+    gl_FragColor.rgb += vec3(imageLoad(waveSim2, ivec2(gl_FragCoord.xy)*16).x);
 
     vec2 offsetCoords = vec2(gl_FragCoord.x-840.0, gl_FragCoord.y);
     vec2 waveGradients = vec2(imageLoad(waveSim2, ivec2(offsetCoords)*16).zw);
@@ -225,6 +227,4 @@ void main() {
     if (length(waveNormals.xy) > 0.0) gl_FragColor.rgb += waveNormals;
     }
   #endif
-
-  gl_FragColor.rgb += COLOR;
 }


### PR DESCRIPTION
In `shaders/dimensions/final.fsh`, some code paths don't initialize `gl_FragColor.rgb`, causing black screen on Linux(Mesa Intel).
This PR fixed it.
Not sure if `debug_WATERSIM` works as intended.

# Before the fix
<img width="854" height="480" alt="2025-11-09_12 44 07" src="https://github.com/user-attachments/assets/398809e4-1e43-47c4-965b-87431c5055cd" />

# After the fix
<img width="854" height="480" alt="2025-11-09_13 14 04" src="https://github.com/user-attachments/assets/865799ec-8085-4528-a7b0-74d103a2aff8" />

# F3 screenshot (for system information)
<img width="2880" height="1620" alt="2025-11-09_12 55 30" src="https://github.com/user-attachments/assets/2be9d6d2-ac80-4d0e-8620-cd0726322fdf" />


