### PR TITLE
Use lowercase format layout qualifier in prepare*.csh

### DIFF
--- a/shaders/dimensions/prepare1.csh
+++ b/shaders/dimensions/prepare1.csh
@@ -37,8 +37,8 @@ layout (local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
 #endif
 
 
-layout (RG16F) uniform image2D waveSim;
-layout (RGBA16F) uniform image2D waveSim2;
+layout (rg16f) uniform image2D waveSim;
+layout (rgba16f) uniform image2D waveSim2;
 
 const ivec2 resolution = ivec2(workGroups.x * 32, workGroups.y * 32);
 

--- a/shaders/dimensions/prepare2.csh
+++ b/shaders/dimensions/prepare2.csh
@@ -37,8 +37,8 @@ layout (local_size_x = 32, local_size_y = 32, local_size_z = 1) in;
 #endif
 
 
-layout (RG16F) uniform image2D waveSim;
-layout (RGBA16F) uniform image2D waveSim2;
+layout (rg16f) uniform image2D waveSim;
+layout (rgba16f) uniform image2D waveSim2;
 
 const ivec2 resolution = ivec2(workGroups.x * 32, workGroups.y * 32);
 


### PR DESCRIPTION
According to [OpenGL Specification](https://registry.khronos.org/OpenGL/specs/gl/glspec46.core.pdf) (in table 8.26), format layout qualifiers, like `rg16f` in `layout (rg16f)`, should be lowercase.


However, in `shaders/dimensions/prepare1.csh` and `shaders/dimensions/prepare2.csh`, the format layout qualifiers of `waveSim` and `waveSim2` are uppercase, causing compile error on Windows Intel platform, as shown in the following screenshot:
<img width="854" height="480" alt="2025-11-18_12 19 43" src="https://github.com/user-attachments/assets/569c7034-dfa8-49c8-ba29-5cb25e57f072" />


This PR changes them to lowercase and fixs the error:
<img width="854" height="480" alt="2025-11-18_12 27 47" src="https://github.com/user-attachments/assets/5edff321-8d2d-4b86-85e4-ee391d6058a6" />
